### PR TITLE
Avoid reversing the slice

### DIFF
--- a/balloon.go
+++ b/balloon.go
@@ -131,8 +131,7 @@ func (b *Instance) Mix(h hash.Hash, salt []byte, sCost, tCost uint64) {
 
 				// math/big usually uses big-endian, with the exception of
 				// SetBits. We can unsafely convert otherBytes directly into
-				// a slice of big.Word to bypass the need to reverse
-				// otherBytes.
+				// a big.Word slice to bypass the need to reverse otherBytes.
 				header := *(*reflect.SliceHeader)(unsafe.Pointer(&otherBytes))
 				header.Len /= SizeOfWord
 				header.Cap /= SizeOfWord

--- a/balloon.go
+++ b/balloon.go
@@ -130,8 +130,9 @@ func (b *Instance) Mix(h hash.Hash, salt []byte, sCost, tCost uint64) {
 				otherBytes := h.Sum(nil)
 
 				// math/big usually uses big-endian, with the exception of
-				// SetBits. We can unsafely convert otherBytes directly into
-				// a big.Word slice to bypass the need to reverse otherBytes.
+				// Int.SetBits. We can unsafely convert otherBytes directly
+				// into a big.Word slice to bypass the need to reverse
+				// otherBytes.
 				header := *(*reflect.SliceHeader)(unsafe.Pointer(&otherBytes))
 				header.Len /= SizeOfWord
 				header.Cap /= SizeOfWord

--- a/balloon_test.go
+++ b/balloon_test.go
@@ -35,54 +35,54 @@ func BenchmarkBalloonM(b *testing.B) {
 }
 
 func TestBalloonVectors(t *testing.T) {
-	type test_vector struct {
+	type testVector struct {
 		password []byte
-		salt []byte
-		s_cost uint64
-		t_cost uint64
-		output string
+		salt     []byte
+		sCost    uint64
+		tCost    uint64
+		output   string
 	}
 
-	test_vectors := []test_vector{
+	testVectors := []testVector{
 		{
 			password: []byte("hunter42"),
-			salt: []byte("examplesalt"),
-			s_cost: 1024,
-			t_cost: 3,
-			output: "716043dff777b44aa7b88dcbab12c078abecfac9d289c5b5195967aa63440dfb",
+			salt:     []byte("examplesalt"),
+			sCost:    1024,
+			tCost:    3,
+			output:   "716043dff777b44aa7b88dcbab12c078abecfac9d289c5b5195967aa63440dfb",
 		},
 		{
 			password: []byte(""),
-			salt: []byte("salt"),
-			s_cost: 3,
-			t_cost: 3,
-			output: "5f02f8206f9cd212485c6bdf85527b698956701ad0852106f94b94ee94577378",
+			salt:     []byte("salt"),
+			sCost:    3,
+			tCost:    3,
+			output:   "5f02f8206f9cd212485c6bdf85527b698956701ad0852106f94b94ee94577378",
 		},
 		{
 			password: []byte("password"),
-			salt: []byte(""),
-			s_cost: 3,
-			t_cost: 3,
-			output: "20aa99d7fe3f4df4bd98c655c5480ec98b143107a331fd491deda885c4d6a6cc",
+			salt:     []byte(""),
+			sCost:    3,
+			tCost:    3,
+			output:   "20aa99d7fe3f4df4bd98c655c5480ec98b143107a331fd491deda885c4d6a6cc",
 		},
 		{
 			password: []byte("\000"),
-			salt: []byte("\000"),
-			s_cost: 3,
-			t_cost: 3,
-			output: "4fc7e302ffa29ae0eac31166cee7a552d1d71135f4e0da66486fb68a749b73a4",
+			salt:     []byte("\000"),
+			sCost:    3,
+			tCost:    3,
+			output:   "4fc7e302ffa29ae0eac31166cee7a552d1d71135f4e0da66486fb68a749b73a4",
 		},
 		{
 			password: []byte("password"),
-			salt: []byte("salt"),
-			s_cost: 1,
-			t_cost: 1,
-			output: "eefda4a8a75b461fa389c1dcfaf3e9dfacbc26f81f22e6f280d15cc18c417545",
+			salt:     []byte("salt"),
+			sCost:    1,
+			tCost:    1,
+			output:   "eefda4a8a75b461fa389c1dcfaf3e9dfacbc26f81f22e6f280d15cc18c417545",
 		},
 	}
 
-	for _, vector := range test_vectors {
-		output := Balloon(sha256.New(), vector.password, vector.salt, vector.s_cost, vector.t_cost)
+	for _, vector := range testVectors {
+		output := Balloon(sha256.New(), vector.password, vector.salt, vector.sCost, vector.tCost)
 		data, err := hex.DecodeString(vector.output)
 
 		if err != nil {
@@ -97,84 +97,84 @@ func TestBalloonVectors(t *testing.T) {
 }
 
 func TestBalloonMVectors(t *testing.T) {
-	type test_vector struct {
+	type testVector struct {
 		password []byte
-		salt []byte
-		s_cost uint64
-		t_cost uint64
-		p_cost uint64
-		output string
+		salt     []byte
+		sCost    uint64
+		tCost    uint64
+		pCost    uint64
+		output   string
 	}
 
-	test_vectors := []test_vector{
+	testVectors := []testVector{
 		{
 			password: []byte("hunter42"),
-			salt: []byte("examplesalt"),
-			s_cost: 1024,
-			t_cost: 3,
-			p_cost: 4,
-			output: "1832bd8e5cbeba1cb174a13838095e7e66508e9bf04c40178990adbc8ba9eb6f",
+			salt:     []byte("examplesalt"),
+			sCost:    1024,
+			tCost:    3,
+			pCost:    4,
+			output:   "1832bd8e5cbeba1cb174a13838095e7e66508e9bf04c40178990adbc8ba9eb6f",
 		},
 		{
 			password: []byte(""),
-			salt: []byte("salt"),
-			s_cost: 3,
-			t_cost: 3,
-			p_cost: 2,
-			output: "f8767fe04059cef67b4427cda99bf8bcdd983959dbd399a5e63ea04523716c23",
+			salt:     []byte("salt"),
+			sCost:    3,
+			tCost:    3,
+			pCost:    2,
+			output:   "f8767fe04059cef67b4427cda99bf8bcdd983959dbd399a5e63ea04523716c23",
 		},
 		{
 			password: []byte("password"),
-			salt: []byte(""),
-			s_cost: 3,
-			t_cost: 3,
-			p_cost: 3,
-			output: "bcad257eff3d1090b50276514857e60db5d0ec484129013ef3c88f7d36e438d6",
+			salt:     []byte(""),
+			sCost:    3,
+			tCost:    3,
+			pCost:    3,
+			output:   "bcad257eff3d1090b50276514857e60db5d0ec484129013ef3c88f7d36e438d6",
 		},
 		{
 			password: []byte("password"),
-			salt: []byte(""),
-			s_cost: 3,
-			t_cost: 3,
-			p_cost: 1,
-			output: "498344ee9d31baf82cc93ebb3874fe0b76e164302c1cefa1b63a90a69afb9b4d",
+			salt:     []byte(""),
+			sCost:    3,
+			tCost:    3,
+			pCost:    1,
+			output:   "498344ee9d31baf82cc93ebb3874fe0b76e164302c1cefa1b63a90a69afb9b4d",
 		},
 		{
 			password: []byte("\000"),
-			salt: []byte("\000"),
-			s_cost: 3,
-			t_cost: 3,
-			p_cost: 4,
-			output: "8a665611e40710ba1fd78c181549c750f17c12e423c11930ce997f04c7153e0c",
+			salt:     []byte("\000"),
+			sCost:    3,
+			tCost:    3,
+			pCost:    4,
+			output:   "8a665611e40710ba1fd78c181549c750f17c12e423c11930ce997f04c7153e0c",
 		},
 		{
 			password: []byte("\000"),
-			salt: []byte("\000"),
-			s_cost: 3,
-			t_cost: 3,
-			p_cost: 1,
-			output: "d9e33c683451b21fb3720afbd78bf12518c1d4401fa39f054b052a145c968bb1",
+			salt:     []byte("\000"),
+			sCost:    3,
+			tCost:    3,
+			pCost:    1,
+			output:   "d9e33c683451b21fb3720afbd78bf12518c1d4401fa39f054b052a145c968bb1",
 		},
 		{
 			password: []byte("password"),
-			salt: []byte("salt"),
-			s_cost: 1,
-			t_cost: 1,
-			p_cost: 16,
-			output: "a67b383bb88a282aef595d98697f90820adf64582a4b3627c76b7da3d8bae915",
+			salt:     []byte("salt"),
+			sCost:    1,
+			tCost:    1,
+			pCost:    16,
+			output:   "a67b383bb88a282aef595d98697f90820adf64582a4b3627c76b7da3d8bae915",
 		},
 		{
 			password: []byte("password"),
-			salt: []byte("salt"),
-			s_cost: 1,
-			t_cost: 1,
-			p_cost: 1,
-			output: "97a11df9382a788c781929831d409d3599e0b67ab452ef834718114efdcd1c6d",
+			salt:     []byte("salt"),
+			sCost:    1,
+			tCost:    1,
+			pCost:    1,
+			output:   "97a11df9382a788c781929831d409d3599e0b67ab452ef834718114efdcd1c6d",
 		},
 	}
 
-	for _, vector := range test_vectors {
-		output := BalloonM(sha256.New, vector.password, vector.salt, vector.s_cost, vector.t_cost, vector.p_cost)
+	for _, vector := range testVectors {
+		output := BalloonM(sha256.New, vector.password, vector.salt, vector.sCost, vector.tCost, vector.pCost)
 		data, err := hex.DecodeString(vector.output)
 
 		if err != nil {


### PR DESCRIPTION
This PR aims to remove the need to reverse the bytes slice when using math/big. I also made some of the variable/type naming more consistent (Go uses camel-case) and fixed a few typos.

I saw that there was an issue with math/big using primarily big-endian in its package. Oddly, I came across this function https://pkg.go.dev/math/big#Int.SetBits that uses little-endian.

It's possible (in a rather hacky way) to use the unsafe package to type cast the bytes slice into a big.Word slice and use SetBits without the need to reverse a slice.

Here are the given benchmark tests, showing a slight improvement.

With reverse
```
BenchmarkBalloon
BenchmarkBalloon-4          6135           1736703 ns/op
BenchmarkBalloonM
BenchmarkBalloonM-4         4665           2638889 ns/op
```

Without reverse
```
BenchmarkBalloon
BenchmarkBalloon-4          6474           1692983 ns/op
BenchmarkBalloonM
BenchmarkBalloonM-4         4732           2511378 ns/op
```

I think more can be squeezed out of this hashing implementation, but it'll need more looking into.